### PR TITLE
fix: incorrect handling of empty Tags object

### DIFF
--- a/src/f5_ai_gateway_sdk/result.py
+++ b/src/f5_ai_gateway_sdk/result.py
@@ -81,7 +81,7 @@ class Result(BaseModel):
             self.modified_prompt = None
             self.modified_response = None
 
-        if bool(self.tags) and not annotate:
+        if self.tags and not annotate:
             logging.warning(
                 "%s tried to annotate request with tags when parameters.annotate was set to false, tags will be dropped",
                 processor_name,

--- a/src/f5_ai_gateway_sdk/result.py
+++ b/src/f5_ai_gateway_sdk/result.py
@@ -81,7 +81,7 @@ class Result(BaseModel):
             self.modified_prompt = None
             self.modified_response = None
 
-        if self.tags is not None and not annotate:
+        if bool(self.tags) and not annotate:
             logging.warning(
                 "%s tried to annotate request with tags when parameters.annotate was set to false, tags will be dropped",
                 processor_name,

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -10,6 +10,7 @@ import pytest
 from f5_ai_gateway_sdk.request_input import RequestInput
 from f5_ai_gateway_sdk.response_output import ResponseOutput
 from f5_ai_gateway_sdk.result import Result
+from f5_ai_gateway_sdk.tags import Tags
 
 
 def test_prompt_not_allowed_with_response():
@@ -22,3 +23,62 @@ def test_prompt_not_allowed_with_response():
             modified_prompt=RequestInput(messages=[]),
             modified_response=ResponseOutput(choices=[]),
         )
+
+
+@pytest.mark.parametrize(
+    "name,annotate,modify,result,expected_log",
+    [
+        (
+            "Annotate not allowed",
+            False,
+            False,
+            Result(tags=Tags({"test": ["value"]})),
+            "test_processor tried to annotate request with tags when parameters.annotate was set to false, tags will be dropped",
+        ),
+        ("Treat empty Tags as no annotate", False, False, Result(tags=Tags()), ""),
+        (
+            "Modify not allowed for prompt",
+            True,
+            False,
+            Result(modified_prompt=RequestInput(messages=[])),
+            "test_processor tried to modify request when parameters.modify was set to false, modification will be dropped",
+        ),
+        (
+            "Modify not allowed for response",
+            True,
+            False,
+            Result(modified_response=ResponseOutput(choices=[])),
+            "test_processor tried to modify request when parameters.modify was set to false, modification will be dropped",
+        ),
+        (
+            "Modify allowed",
+            False,
+            True,
+            Result(modified_response=ResponseOutput(choices=[])),
+            "",
+        ),
+        (
+            "Annotate allowed",
+            True,
+            True,
+            Result(tags=Tags(), modified_prompt=RequestInput(messages=[])),
+            "",
+        ),
+    ],
+    ids=lambda name: name,
+)
+def test_validate_not_allowed_parameters(
+    caplog, name, annotate: bool, modify: bool, result: Result, expected_log
+):
+    """Test validate_allowed drops modifications or tags which have not been approved."""
+    result.validate_allowed("test_processor", annotate, modify)
+
+    if expected_log:
+        assert expected_log in caplog.text
+    else:
+        assert len(caplog.records) == 0
+    if not annotate:
+        assert not bool(result.tags)
+    if not modify:
+        assert result.modified_prompt is None
+        assert result.modified_response is None


### PR DESCRIPTION
### Proposed changes

`None` check for tags object was not appropriate for verifying if a `Result` had tags, switching to using the `Tags` object `__bool__` implementation.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests (when possible) that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto main
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
